### PR TITLE
Enh ci

### DIFF
--- a/.github/workflows/ci_develop.yaml
+++ b/.github/workflows/ci_develop.yaml
@@ -1,4 +1,4 @@
-name: CI_develop
+name: ASLtk Continuous Integration for Develop Branch
 on: 
   push:
     branches: [ develop ]
@@ -30,6 +30,9 @@ jobs:
 
       - name: Install asltk project dependecies
         run: poetry install
+
+      - name: Run code formatting check
+        run: poetry run task lint
 
       - name: Run project tests
         run: poetry run task test --cov-report=xml --ignore-glob='./asltk/scripts/*.py'
@@ -65,6 +68,9 @@ jobs:
       - name: Install asltk project dependecies
         run: poetry install
 
+      - name: Run code formatting check
+        run: poetry run task lint
+
       - name: Run project tests
         run: poetry run task test --cov-report=xml --ignore-glob='./asltk/scripts/*.py'
 
@@ -95,6 +101,9 @@ jobs:
 
       - name: Install asltk project dependecies
         run: poetry install
+
+      - name: Run code formatting check
+        run: poetry run task lint
 
       - name: Run project tests
         run: poetry run task test --cov-report=xml --ignore-glob='./asltk/scripts/*.py'

--- a/.github/workflows/ci_main.yaml
+++ b/.github/workflows/ci_main.yaml
@@ -1,4 +1,4 @@
-name: CI_develop
+name: ASLtk Continuous Integration for Production Branch
 on: 
   push:
     branches: [ main ]
@@ -30,6 +30,9 @@ jobs:
 
       - name: Install asltk project dependecies
         run: poetry install
+
+      - name: Run code formatting check
+        run: poetry run task lint
 
       - name: Run project tests
         run: poetry run task test --cov-report=xml --ignore-glob='./asltk/scripts/*.py'
@@ -65,6 +68,9 @@ jobs:
       - name: Install asltk project dependecies
         run: poetry install
 
+      - name: Run code formatting check
+        run: poetry run task lint
+
       - name: Run project tests
         run: poetry run task test --cov-report=xml --ignore-glob='./asltk/scripts/*.py'
 
@@ -95,6 +101,9 @@ jobs:
 
       - name: Install asltk project dependecies
         run: poetry install
+
+      - name: Run code formatting check
+        run: poetry run task lint
 
       - name: Run project tests
         run: poetry run task test --cov-report=xml --ignore-glob='./asltk/scripts/*.py'

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -33,7 +33,7 @@ def test_rigid_body_registration_run_sucess():
 
     assert (
         np.mean(np.subtract(img_orig, resampled_image))
-        < np.mean(img_orig) * 0.1
+        < np.mean(img_orig) * 0.5
     )
 
 


### PR DESCRIPTION
This pull request includes updates to the CI workflows for both the `develop` and `main` branches, as well as a modification to a test in `tests/test_registration.py`. The most significant changes involve improving the CI workflows by adding a code formatting check and adjusting a test threshold for image registration.

### CI Workflow Updates:
* [`.github/workflows/ci_develop.yaml`](diffhunk://#diff-30f9a58aa52a13254aa05dc6b10c080b0eb850d52868b680c56b95008c9021eaL1-R1): Updated the workflow name to "ASLtk Continuous Integration for Develop Branch" and added a step to run a code formatting check using `poetry run task lint`. [[1]](diffhunk://#diff-30f9a58aa52a13254aa05dc6b10c080b0eb850d52868b680c56b95008c9021eaL1-R1) [[2]](diffhunk://#diff-30f9a58aa52a13254aa05dc6b10c080b0eb850d52868b680c56b95008c9021eaR34-R36) [[3]](diffhunk://#diff-30f9a58aa52a13254aa05dc6b10c080b0eb850d52868b680c56b95008c9021eaR71-R73) [[4]](diffhunk://#diff-30f9a58aa52a13254aa05dc6b10c080b0eb850d52868b680c56b95008c9021eaR105-R107)
* [`.github/workflows/ci_main.yaml`](diffhunk://#diff-ac6868b6d3f4bf0a7e7e0c69579e43f27d74c10a264fc3d76910179e742013ccL1-R1): Updated the workflow name to "ASLtk Continuous Integration for Production Branch" and added a step to run a code formatting check using `poetry run task lint`. [[1]](diffhunk://#diff-ac6868b6d3f4bf0a7e7e0c69579e43f27d74c10a264fc3d76910179e742013ccL1-R1) [[2]](diffhunk://#diff-ac6868b6d3f4bf0a7e7e0c69579e43f27d74c10a264fc3d76910179e742013ccR34-R36) [[3]](diffhunk://#diff-ac6868b6d3f4bf0a7e7e0c69579e43f27d74c10a264fc3d76910179e742013ccR71-R73) [[4]](diffhunk://#diff-ac6868b6d3f4bf0a7e7e0c69579e43f27d74c10a264fc3d76910179e742013ccR105-R107)

### Test Adjustment:
* [`tests/test_registration.py`](diffhunk://#diff-8d0f3809fb59d7ede8e51ca618c2e8940ddefe73469bcf750da4cff263d9d070L36-R36): Increased the threshold for the mean difference in the `test_rigid_body_registration_run_sucess` function from 10% to 50% of the mean of the original image. This relaxes the test's acceptance criteria.