### PR TITLE
Quick Assistance #53

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,20 @@ Thank you all the special people that invested their time and knowledge to impro
 We appreciate if one or more of the following references can be added in your projects due to the usage of `asltk` outcomes.
 
 * Paper 1
+
+## Quick Assistance
+
+Need help with basic ASL data processing?
+
+Check out our new guide:  
+[QUICK ASSISTANCE](docs/quick_assistance.md)
+
+It includes ready-to-use code for:
+- Loading/saving ASL images
+- Changing PLD/LD parameters
+- Creating CBF maps
+- Generating T1-BLG mappings
+- Logging and debugging
+
+Perfect for beginners or quick reference during prototyping.
+

--- a/docs/quick_assistance.md
+++ b/docs/quick_assistance.md
@@ -1,0 +1,70 @@
+# **Quick Assistance**
+
+This section provides minimal examples of common tasks in `asltk`, to help new users get started quickly.
+
+Each snippet includes links to full guides and deeper usage in the rest of the documentation.
+
+---
+
+## Load and Save an ASL Image
+
+```python
+from asltk.io import load_asl, save_asl
+
+asl_data = load_asl("input_asl.nii.gz")
+save_asl(asl_data, "output_asl.nii.gz")
+```
+* Related: [Examples](docs/usage_examples.md), [Getting started](docs/getting_started.md)
+---
+## Modify Parameters of an ASL Image
+```python
+from asltk.io import load_asl
+
+asl_data = load_asl("image.nii.gz")
+asl_data.pld_values = [1.5]  # Update post-label delay
+asl_data.ld_values = [1.8]   # Update label duration
+```
+---
+## Copy an ASL Dataset
+```python
+from copy import deepcopy
+from asltk.io import load_asl
+
+asl_data = load_asl("scan.nii.gz")
+asl_copy = deepcopy(asl_data)
+```
+---
+## Create T1-BLG Map from MultiTE-ASL
+```python
+from asltk.io import load_asl
+from asltk.multite import generate_t1blgm_map
+
+multi_te_asl = load_asl("multite_asl.nii.gz")
+t1blgm_map = generate_t1blgm_map(multi_te_asl)
+```
+* see also: [usage examples](usage_examples.md)
+---
+## Modify Parameters Before Reconstruction
+```python
+from asltk.io import load_asl
+from asltk.recon import CBFReconstruction
+
+asl_data = load_asl("input_asl.nii.gz")
+asl_data.pld_values = [2.0]
+asl_data.ld_values = [1.5]
+
+cbf = CBFReconstruction()
+cbf_map = cbf.run(asl_data)
+```
+---
+## Add Logging to a Script
+```python
+from asltk import setup_logging, get_logger
+
+setup_logging(level="INFO", console_output=True)
+logger = get_logger()
+logger.info("Starting ASL processing...")
+```
+* See: [logging](logging.md)
+* full logging guide: [logging](logging.md)
+---


### PR DESCRIPTION
# **Pull Request: Add "Quick Assistance" Section to Docs and README #53**
## Description
This PR addresses [Issue #53](https://github.com/LOAMRI/asltk/issues/53) by introducing a new "Quick Assistance" section designed to help new users quickly perform common tasks with asltk.

### Changes Included
#### 1. New Documentation Page
* Added docs/quick_assistance.md
* Contains concise examples for:
   - Loading/saving ASL images
   - Modifying PLD and LD parameters
   - Copying ASL datasets
   - Creating T1-BLG mappings
   - Running CBF reconstruction
   - Using the logging system
* Internal cross-links to related pages (e.g. usage_examples.md, logging.md)

#### 2. Updated README
* Added a short "Quick Assistance" reference block
* Directs users to the full guide on ReadTheDocs

#### 3. MkDocs Configuration
* Updated mkdocs.yml to include the new quick_assistance.md in the navigation

## Why This Matters
This update provides:
* Faster onboarding for new users
* Copy-paste ready examples
* A centralized reference hub for common ASL tasks

## Related
Closes #53 
Docs link: Quick Assistance on ReadTheDocs

@acsenrafilho Please check, review and merge
Thank You